### PR TITLE
Update vim/syntax/twelf.vim

### DIFF
--- a/vim/syntax/twelf.vim
+++ b/vim/syntax/twelf.vim
@@ -77,8 +77,8 @@ hi link twelfSquare            twelfSquareFace
 " Folds
 "syn region myFold start="%{" end="}%" transparent fold 
 "syn sync fromstart
+"set foldmethod=syntax
+"set foldminlines=3
 
-set foldmethod=syntax
-set foldminlines=3
 " Set the current syntax name
 let b:current_syntax = "twelf"


### PR DESCRIPTION
Remove foldmethod=syntax, since no Twelf syntax was marked foldable, and it overrides the default foldmethod.
