### PR TITLE
[CI] Clean up Actions workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,20 +1,29 @@
-# https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container
-
-name: Run Tests
+name: Twelf Regression Suite
 
 on:
   push:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  build:
+  build-test:
     runs-on: ubuntu-latest
-    container:
-      image: jcreed/mlton-twelf-ci:latest # built from https://github.com/jcreedcmu/docker-mlton
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          mkdir mlton && cd mlton
+          curl -O -L https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-linux-glibc2.31.tgz
+          tar xzf mlton-20210117-1.amd64-linux-glibc2.31.tgz
+          cd mlton-20210117-1.amd64-linux-glibc2.31 && sudo make install
+          echo -e '#!/bin/bash\ngit rev-parse HEAD' > /tmp/svnversion
+          chmod +x /tmp/svnversion
+          sudo cp /tmp/svnversion /usr/local/bin
+
       - name: Run tests
         run: cd TEST && ./regression.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Twelf
 =====
-![run tests](https://github.com/standardml/twelf/actions/workflows/run-tests.yml/badge.svg?branch=main)
+[![run tests](https://github.com/standardml/twelf/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/standardml/twelf/actions/workflows/run-tests.yml)
 
 Copyright (C) 1997-2011, Frank Pfenning and Carsten Schuermann
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Twelf
 =====
-![run tests](https://github.com/standardml/twelf/actions/workflows/run-tests.yml/badge.svg)
+![run tests](https://github.com/standardml/twelf/actions/workflows/run-tests.yml/badge.svg?branch=main)
 
 Copyright (C) 1997-2011, Frank Pfenning and Carsten Schuermann
 
@@ -49,4 +49,3 @@ Files
     src/              --- the SML sources for Twelf
     tex/              --- TeX macros and style files
     vim/              --- Vim interface for Twelf
-

--- a/TEST/regression.sh
+++ b/TEST/regression.sh
@@ -9,6 +9,9 @@
 # if any second argument is given, the script also runs several plparty.org
 # specific extra regression checks.
 
+# Exit on error
+set -e
+
 MLTON="mlton"
 SML="sml"
 SML_FLAGS="-Ccm.verbose=false -Ccompiler-mc.warn-non-exhaustive-match=false sources.cm -Ccompiler-mc.warn-non-exhaustive-bind=false -Ccontrol.poly-eq-warn=false"


### PR DESCRIPTION
- The `regression.sh` now has `set -e` so that test failures in suites other than the last one will propagate their nonzero error code and correctly report as errors.

- There is no need to use a custom docker image. Following the example of MLton's own CI configuration, we can simply install the MLton compiler on the github runner.

- The `README.md` badge now refers to the main branch. This means that we won't see misleading failure reported for failures on PRs.

- Added `workflow_dispatch` to workflow triggers so that we can trigger manually if convenient.