### PR TITLE
Account for primary branch name change

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: Twelf Regression Suite
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
I think this ought to fix the "no status" showing on the CI badge at the moment.