### PR TITLE
[WASI] Add unsafe setter to wasm interface

### DIFF
--- a/.github/workflows/build-wiki.yml
+++ b/.github/workflows/build-wiki.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Build wiki
         run: cd wiki && npm i && npm run build
 
-		- name: Sanitize Artifact Name
-		  run: |
-		    name="${{ github.head_ref || github.ref_name }}"
+      - name: Sanitize Artifact Name
+        run: |
+          name="${{ github.head_ref || github.ref_name }}"
           name=$(echo -n "$name" | sed -e 's/[":<>\|*?\r\n\\\/]/-/g')
-			 echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
 
       - name: Upload wiki as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wiki.yml
+++ b/.github/workflows/build-wiki.yml
@@ -38,10 +38,16 @@ jobs:
       - name: Build wiki
         run: cd wiki && npm i && npm run build
 
+		- name: Sanitize Artifact Name
+		  run: |
+		    name="${{ github.head_ref || github.ref_name }}"
+          name=$(echo -n "$name" | sed -e 's/[":<>\|*?\r\n\\\/]/-/g')
+			 echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
+
       - name: Upload wiki as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wiki-ssg-${{ github.head_ref || github.ref_name }}
+          name: wiki-ssg-${{ env.ARTIFACT_NAME }}
           path: wiki/dist/
           compression-level: 9
           retention-days: 1

--- a/build/twelf-wasi.sml
+++ b/build/twelf-wasi.sml
@@ -19,6 +19,14 @@
  *   buffer, which will result in various print statements. The caller
  *   is expected to implement the WASI fd_write endpoint so that they
  *   can see the output so printed.
+ *
+ * unsafe : bool -> unit
+ *   unsafe(u) has the side effect of setting the unsafe parameter to
+ *   u. What we'd like to do in the future (to avoid recapitulating
+ *   server.sml here) is expose the rest of the Twelf server protocol
+ *   here in a more uniform way, but string handling across the
+ *   js-wasm-sml boundary is awkward. It may improve with the
+ *   forthcoming wasi2 standard.
  *)
 
 val bref: CharArray.array option ref = ref NONE
@@ -42,3 +50,6 @@ val _ = e (fn () =>
 				  in
 					 codeOfStatus status
 				  end)
+
+val e = _export "unsafe": (bool -> unit) -> unit;
+val _ = e (fn (unsafe) => Twelf.unsafe := unsafe)

--- a/build/twelf-wasi.sml
+++ b/build/twelf-wasi.sml
@@ -26,7 +26,7 @@
  *   server.sml here) is expose the rest of the Twelf server protocol
  *   here in a more uniform way, but string handling across the
  *   js-wasm-sml boundary is awkward. It may improve with the
- *   forthcoming wasi2 standard.
+ *   forthcoming wasip2 standard.
  *)
 
 val bref: CharArray.array option ref = ref NONE


### PR DESCRIPTION
This is in support of https://github.com/jcreedcmu/twelf-wasm/issues/3

Fix in passing the github workflow that constructs a wiki artifact, by sanitizing the branch name to not contain forbidden characters such as `/`.