### PR TITLE
[WASI] Import rather than export memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ twelf-lib-mlton-wasi:
 		-format libexecutable \
 		-output bin/twelf.wasm \
 		-default-ann 'allowFFI true' \
+		-link-opt -Wl,--import-memory \
 		build/twelf-lib-mlton-wasi.mlb
 
 .PHONY: twelf-server-smlnj


### PR DESCRIPTION
Previously, the `.wasm` we produce *exports* its `WebAssembly.Memory` object. This fixes it at compile-time to be unshared and of a fixed maximum size.

Instead, apply a flag during sml-to-wasm compilation (through a message wrapped in two command-line envelopes, as it were: we tell mlton `-link-opt` so that it tells gcc to `-Wl,` so that it tells `wasm-ld` to `--import-memory`) so that the `.wasm` produced expects a `WebAssembly.Memory` as one of its *imports*. This means that whoever consumes the `.wasm` can flexibly decide what memory object to supply it.