### PR TITLE
Proxy with a slightly different method

### DIFF
--- a/wiki/astro.config.mjs
+++ b/wiki/astro.config.mjs
@@ -5,6 +5,12 @@ import starlightLinksValidator from "starlight-links-validator";
 // https://astro.build/config
 export default defineConfig({
   site: "https://twelf.org",
+  redirects:
+    import.meta.env.MODE === "development"
+      ? {
+          "/twelf-wasm/": "/twelf-wasm/index.html",
+        }
+      : {},
   integrations: [
     starlight({
       title: "Twelf",

--- a/wiki/src/pages/twelf-wasm/[...path].ts
+++ b/wiki/src/pages/twelf-wasm/[...path].ts
@@ -15,6 +15,7 @@ export function getStaticPaths() {
     { params: { path: "assets/twelf-icon.png" } },
     { params: { path: "assets/worker.js" } },
     { params: { path: "css/style.css" } },
+    { params: { path: "index.html" } },
   ];
 }
 

--- a/wiki/src/pages/twelf-wasm/go.ts
+++ b/wiki/src/pages/twelf-wasm/go.ts
@@ -1,7 +1,0 @@
-export const GET = async () => {
-  return new Response(
-    await fetch(`https://jcreedcmu.github.io/twelf-wasm/`).then((response) =>
-      response.blob()
-    )
-  );
-};


### PR DESCRIPTION
This approach feels a bit more consistent and honest, with just a slight twist to keep twelf-wasm/index.html from getting written in two incompaible ways