### PR TITLE
Change wasi target to "wasm32-wasi"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ twelf-server-mlton:
 
 .PHONY: twelf-lib-mlton-wasi
 twelf-lib-mlton-wasi:
-	$(mlton) -target wasm32-unknown-wasi \
+	$(mlton) -target wasm32-wasi \
 		-format libexecutable \
 		-output bin/twelf.wasm \
 		-default-ann 'allowFFI true' \


### PR DESCRIPTION
This is to reflect the upstream change in
https://github.com/WebAssembly/wasi-sdk/pull/388.