### PR TITLE
Update proving-metatheorems pages

### DIFF
--- a/wiki/pages/proving-metatheorems-proving-metatheorems-in-non-empty-contexts.elf
+++ b/wiki/pages/proving-metatheorems-proving-metatheorems-in-non-empty-contexts.elf
@@ -2,16 +2,16 @@
 %%! prev:
 %%!    label: "Proving totality assertions in non-empty contexts"
 %%!    link: /wiki/proving-metatheorems-proving-totality-assertions-in-non-empty-contexts/
-
+%%! next:
+%%!    label: "Summary"
+%%!    link: /wiki/proving-metatheorems-summary-the-stlc/
 %{! 
 
 _This page is part of the introduction to [proving metatheorems with Twelf](/wiki/proving-metatheorems-with-twelf/)._
 
-(This part of the tutorial isn't cleaned up from the transition from MediaWiki, the archived page may have better formatting)
-
 By using Twelf's ability to prove totality assertions for type families in general worlds, we can mechanize metatheorems about open LF terms.  We prove a simple metatheorem about the judgement ``size E N`` as an example. !}%
     
-%{! (options removed from twelftag: hidden="true") !}%
+%{!! begin hidden !!}%
 
 tp    : type.
 unit  : tp.
@@ -31,14 +31,14 @@ plus   : nat -> nat -> nat -> type.
 
 plus-z : plus z N2 N2.
 plus-s : plus (s N1) N2 (s N3)
-	  <- plus N1 N2 N3.
+       <- plus N1 N2 N3.
 
 %worlds () (plus _ _ _).
 %total N (plus N _ _).
 
-%{!  !}%
+%{!! end hidden !!}%
     
-%{! (options removed from twelftag: hidden="true") !}%
+%{!! begin hidden !!}%
 
 plus-exists : {N1} {N2} plus N1 N2 N3 -> type.
 %mode plus-exists +X1 +X2 -X3.
@@ -96,9 +96,9 @@ id/nat-s-cong : id/nat N1 N2
 %total {} (id/nat-s-cong _ _).
 
 plus-unique : plus N1 N2 N3
-	      -> plus N1 N2 N3'
-	      -> id/nat N3 N3'
-	      -> type.
+           -> plus N1 N2 N3'
+           -> id/nat N3 N3'
+           -> type.
 %mode plus-unique +X1 +X2 -X3.
 
 - : plus-unique D D id/nat-refl.
@@ -158,10 +158,10 @@ plus-assoc : plus A B AB
 %total D (plus-assoc D _ _ _).
 
 plus-assoc2 : plus A B AB
-	       -> plus B C BC
-	       -> plus AB C ABC
-	       -> plus A BC ABC
-	       -> type.
+            -> plus B C BC
+            -> plus AB C ABC
+            -> plus A BC ABC
+            -> type.
 %mode plus-assoc2 +X1 +X2 -X3 +X4.
 
 - : plus-assoc2 D1 D2 D3' D4
@@ -175,11 +175,11 @@ plus-assoc2 : plus A B AB
 %total {} (plus-assoc2 _ _ _ _).
 
 lemma : plus N1 N2 Nsum	      
-	 -> plus Ndiff1 N1 N1'
-	 -> plus Ndiff2 N2 N2'
-	 -> plus N1' N2' Nsum'
-	 -> plus Ndiff Nsum  Nsum'
-	 -> type.
+      -> plus Ndiff1 N1 N1'
+      -> plus Ndiff2 N2 N2'
+      -> plus N1' N2' Nsum'
+      -> plus Ndiff Nsum  Nsum'
+      -> type.
 %mode lemma +X1 +X2 +X3 +X4 -X5.
 
 - : lemma 
@@ -198,64 +198,60 @@ lemma : plus N1 N2 Nsum
      <- plus-commute D2 (D2' : plus Ndiff2 N2 N2')
      <- plus-exists Ndiff1 Ndiff2 (Ddiff1+2 : plus Ndiff1 Ndiff2 Ndiff1+2)
      <- plus-assoc2 Ddiff1+2 D2' 
-	(Dassoc' : plus Ndiff1+2 N2 Ndiff1+2')
-	Ddiff1+2'
+     (Dassoc' : plus Ndiff1+2 N2 Ndiff1+2')
+     Ddiff1+2'
      <- plus-commute Dassoc' 
-	(Dassoc'' : plus N2 Ndiff1+2 Ndiff1+2')
+     (Dassoc'' : plus N2 Ndiff1+2 Ndiff1+2')
      <- plus-assoc2 D Dassoc'' Dres Dassoc
      <- plus-commute Dres Dres'.
 
 %worlds () (lemma _ _ _ _ _).
 %total {}  (lemma _ _ _ _ _).
 
-%{!  !}%
-    
-%{! (options removed from twelftag: hidden="true") !}%
-
 size       : tm -> nat -> type.
 %mode size +E -N.
 
 size-empty : size empty (s z). 
 size-lam   : size (lam _ E) (s N)
-		<- ({x} {dx : size x (s z)}
-		      size (E x) N).
+          <- ({x} {dx : size x (s z)}
+                size (E x) N).
 size-app   : size (app E1 E2) (s N)
-		<- size E1 N1
-		<- size E2 N2 
-		<- plus N1 N2 N.
+          <- size E1 N1
+          <- size E2 N2 
+          <- plus N1 N2 N.
 
 %block size-block : block {x : tm} {dx : size x (s z)}.
 
 %worlds (size-block) (size _ _).
 %total E (size E _).
 
+%{!! end hidden !!}%
+
 %{! ## Lower bound on size of substitution: Theorem statement
 
 We prove that substitution never decreases the size of a term.  The informal theorem statement is as follows:
 
-: For all terms <Math formula="e'"/> and <Math formula="e"/>, <Math formula="|e| \le |{e'/x}e|"/>.
+> For all terms <Math formula="e'"/> and <Math formula="e"/>, <Math formula="|e| \le |\{e'/x\}e|"/>.
 
 We can restate this theorem relationally as follows:
 
-: For all terms <Math formula="\mathsf{}e'"/> and <Math formula="\mathsf{}e"/>, if <Math formula="\mathsf{}|e| = n"/> and <Math formula="\mathsf{}|{e'/x}e| = n'"/> then there exists an <Math formula="\mathsf{}n_"/> such that <Math formula="\mathsf{}n_ + n = n'"/>.
+> For all terms <Math formula="e'"/> and <Math formula="e"/>, if <Math formula="|e| = n"/> and <Math formula="|\{e'/x\}e| = n'"/> then there exists an <Math formula="n''"/> such that <Math formula="n'' + n = n'"/>.
 
 For pedagogical parsimony, we have defined greater-than in terms of addition, so that we do not need to introduce any additional judgements on numbers here.  Additionally, because ``size`` defines a function, we are free to assume or conclude the derivations of ``size`` as is convenient; in this case, the proof is slightly simpler if we assume these derivations.  
 
 By adequacy, this theorem can be recast as the following statement about LF terms:
 
-: For all Γ in ``(size-block)*``, if ``Γ ⊦ E' : tm`` and ``Γ ⊦ D : \{x:tm\} size x (s z) -> size (E x) N`` and ``Γ ⊦ D' : size (E E') N'`` then there exist ``Ndiff`` and ``Dplus`` such that ``Γ ⊦ Dplus : plus Ndiff N N'``.
+> For all Γ in ``(size-block)*``, if ``Γ ⊦ E' : tm`` and ``Γ ⊦ D : {x:tm} size x (s z) -> size (E x) N`` and ``Γ ⊦ D' : size (E E') N'`` then there exist ``Ndiff`` and ``Dplus`` such that ``Γ ⊦ Dplus : plus Ndiff N N'``.
 
-Considering arbitrary contexts in the world ``(size-block)*`` is necessary to capture the informal theorem statement, which ranges over all possibly-open terms <Math formula="\mathsf{}e"/> and <Math formula="\mathsf{}e'"/>.  The ``size`` derivation for the term <Math formula="\mathsf{}e"/> with a distinguished free variable <Math formula="\mathsf{}x"/> is represented by an LF term of higher type ``\{x:tm\} size x (s z) -> size (E x) N``.  
+Considering arbitrary contexts in the world ``(size-block)*`` is necessary to capture the informal theorem statement, which ranges over all possibly-open terms <Math formula="e"/> and <Math formula="e'"/>.  The ``size`` derivation for the term <Math formula="e"/> with a distinguished free variable <Math formula="x"/> is represented by an LF term of higher type ``{x:tm} size x (s z) -> size (E x) N``.  
 
 We can prove this theorem in Twelf by giving a relation that satisfies the following totality assertion: !}%
     
-%{! (options removed from twelftag: discard=true) !}%
-
 subst-size : {E' : tm}
-	       ({x : tm} size x (s z) -> size (E x) N)
-	       -> size (E E') N'
-	       -> plus Ndiff N N'
-	       -> type.
+               ({x : tm} size x (s z) -> size (E x) N)
+               -> size (E E') N'
+               -> plus Ndiff N N'
+               -> type.
 %mode subst-size +E' +D1 +D2 -DL.
 %worlds (size-block) (subst-size _ _ _ _).
 
@@ -273,11 +269,11 @@ plus-commute : plus N1 N2 N3 -> plus N2 N1 N3 -> type.
 %worlds () (plus-commute _ _).
 
 lemma : plus N1 N2 Nsum	      
-	 -> plus Ndiff1 N1 N1'
-	 -> plus Ndiff2 N2 N2'
-	 -> plus N1' N2' Nsum'
-	 -> plus Ndiff Nsum  Nsum'
-	 -> type.
+         -> plus Ndiff1 N1 N1'
+         -> plus Ndiff2 N2 N2'
+         -> plus N1' N2' Nsum'
+         -> plus Ndiff Nsum  Nsum'
+         -> type.
 %mode lemma +X1 +X2 +X3 +X4 -X5.
 %worlds () (lemma _ _ _ _ _).
 ```
@@ -285,12 +281,12 @@ lemma : plus N1 N2 Nsum
 The first two would be part of an arithmetic library; the third is a simple lemma that is proved directly using commutativity and associativity of addition.
 
 Additionally, the proof of the theorem uses the following easy lemma: !}%
-    
-%{! (options removed from twelftag: check="true") !}%
+
+%{!! begin checked !!}%
 
 size-at-least-one : size E N
-		      -> plus (s z) N' N
-		      -> type.
+                      -> plus (s z) N' N
+                      -> type.
 %mode size-at-least-one +X1 -X2.
 
 - : size-at-least-one _ (plus-s plus-z).
@@ -298,15 +294,17 @@ size-at-least-one : size E N
 %worlds (size-block) (size-at-least-one _ _).
 %total {} (size-at-least-one _ _).
 
-%{! This relation is total because every way to create a term of type ``size E N`` syntactically produces a term of type ``size E (s N')`` for some ``N'``.  The input coverage checker notices this fact by splitting and therefore validates this simple proof.  
+%{!! end checked !!}%
+
+%{! This relation is total because every way to create a term of type ``size E N`` syntactically produces a term of type ``size E (s N')`` for some ``N'``.  The input coverage checker notices this fact by splitting and therefore validates this simple proof.
 
 Next, we attempt a proof of the theorem: !}%
     
 subst-size : {E' : tm}
-	       ({x : tm} size x (s z) -> size (E x) N)
-	       -> size (E E') N'
-	       -> plus Ndiff N N'
-	       -> type.
+               ({x : tm} size x (s z) -> size (E x) N)
+               -> size (E E') N'
+               -> plus Ndiff N N'
+               -> type.
 %mode subst-size +E' +D1 +D2 -DL.
 
 - : subst-size E'
@@ -323,41 +321,41 @@ subst-size : {E' : tm}
 
 - : subst-size E'
      ([x] [dx] 
-	(size-lam ([y] [dy] D x dx y dy)
-	   %% tell reconstruction that T doesn't depend on x
-	   : size (lam T _) _))
+        (size-lam ([y] [dy] D x dx y dy)
+           %% tell reconstruction that T doesn't depend on x
+           : size (lam T _) _))
      (size-lam D')
      Dplus'
      <- ({y : tm}
-	   {dy : size y (s z)}
-	   subst-size E' ([x] [dx] D x dx y dy) (D' y dy) Dplus)
+           {dy : size y (s z)}
+           subst-size E' ([x] [dx] D x dx y dy) (D' y dy) Dplus)
      <- plus-s-rh Dplus Dplus'.
 
 - : subst-size E'
      ([x] [dx] 
-	size-app 
-	(Dplus : plus N1 N2 Nsum)
-	((D2 x dx) : size (E2 x) N2)
-	((D1 x dx) : size (E1 x) N1)
-	)
+        size-app 
+        (Dplus : plus N1 N2 Nsum)
+        ((D2 x dx) : size (E2 x) N2)
+        ((D1 x dx) : size (E1 x) N1)
+        )
      (size-app 
-	(Dplus' : plus N1' N2' Nsum')
-	(D2' : size (E2 E') N2')
-	(D1' : size (E1 E') N1'))
+        (Dplus' : plus N1' N2' Nsum')
+        (D2' : size (E2 E') N2')
+        (D1' : size (E1 E') N1'))
      DplusRes'
      <- subst-size E' D1 
-	(D1' : size (E1 E') N1')
-	(Dplus1 : plus Ndiff1 N1 N1')
+        (D1' : size (E1 E') N1')
+        (Dplus1 : plus Ndiff1 N1 N1')
      <- subst-size E' D2 
-	(D2' : size (E2 E') N2')
-	(Dplus2 : plus Ndiff2 N2 N2')
+        (D2' : size (E2 E') N2')
+        (Dplus2 : plus Ndiff2 N2 N2')
      <- lemma Dplus Dplus1 Dplus2 Dplus' DplusRes
      <- plus-s-rh DplusRes DplusRes'.
 
 %worlds (size-block) (subst-size _ _ _ _).
 
 %{! By now, you should be getting good at reading relational Twelf proofs of metatheorems as the informal proofs they represent.  This proof is slightly more involved than those that we have seen before, but it involves no new machinery.  We call out some of the tricky parts of the proof:
-* The proof inducts over and case-analyzes the LF term of type ``\{x:tm\} size x (s z) -> size (E x) N``.  By inversion, such a term has the form ``[x] [dx] M`` where ``M : size (E x) N``.  Thus, the proof includes one case for each possible ``M``.  This includes each constructor of type ``size``, along with the distinguished variable ``x``.  
+* The proof inducts over and case-analyzes the LF term of type ``{x:tm} size x (s z) -> size (E x) N``.  By inversion, such a term has the form ``[x] [dx] M`` where ``M : size (E x) N``.  Thus, the proof includes one case for each possible ``M``.  This includes each constructor of type ``size``, along with the distinguished variable ``x``.  
 * Make sure you understand why each constant world checks: The ``subst-size`` premise of the case for ``size-lam`` is in an extended context, but that this context stays in the appropriate world.  Additionally, by world subsumption, ``(size-block)*`` subsumes the world containing only the empty context for the arithmetic lemmas.  
 
 However, the totality check fails:
@@ -375,33 +373,33 @@ To fix the proof, we need to cover the case for other variables in the LF contex
 To correct the proof, we work over contexts of a different form.  Only the ``size-lam`` case needs to change, so we elide the others: !}%
     
 subst-size : {E' : tm}
-	       ({x : tm} size x (s z) -> size (E x) N)
-	       -> size (E E') N'
-	       -> plus Ndiff N N'
-	       -> type.
+               ({x : tm} size x (s z) -> size (E x) N)
+               -> size (E E') N'
+               -> plus Ndiff N N'
+               -> type.
 %mode subst-size +E' +D1 +D2 -DL.
 
 - : subst-size E'
      ([x] [dx] 
-	(size-lam ([y] [dy] D x dx y dy)
-	   %% tell reconstruction that T doesn't depend on x
-	   : size (lam T _) _))
+        (size-lam ([y] [dy] D x dx y dy)
+           %% tell reconstruction that T doesn't depend on x
+           : size (lam T _) _))
      (size-lam D')
      Dplus'
      <- ({y : tm}
-	   {dy : size y (s z)}
-	   {_ : {E' : tm} subst-size E'
-		 ([x : tm] [dx : size x (s z)] dy) 
-		 dy 
-		 plus-z}
-	   subst-size E' ([x] [dx] D x dx y dy) (D' y dy) Dplus)
+           {dy : size y (s z)}
+           {_ : {E' : tm} subst-size E'
+              ([x : tm] [dx : size x (s z)] dy) 
+              dy 
+              plus-z}
+           subst-size E' ([x] [dx] D x dx y dy) (D' y dy) Dplus)
      <- plus-s-rh Dplus Dplus'.
 
 %% ...
 
 %{!  !}%
     
-%{! (options removed from twelftag: hidden="true") !}%
+%{!! begin hidden !!}%
 
 - : subst-size E'
      ([x] [dx] dx)
@@ -417,34 +415,36 @@ subst-size : {E' : tm}
 
 - : subst-size E'
      ([x] [dx] 
-	size-app 
-	(Dplus : plus N1 N2 Nsum)
-	((D2 x dx) : size (E2 x) N2)
-	((D1 x dx) : size (E1 x) N1)
-	)
+     size-app 
+     (Dplus : plus N1 N2 Nsum)
+     ((D2 x dx) : size (E2 x) N2)
+     ((D1 x dx) : size (E1 x) N1)
+     )
      (size-app 
-	(Dplus' : plus N1' N2' Nsum')
-	(D2' : size (E2 E') N2')
-	(D1' : size (E1 E') N1'))
+     (Dplus' : plus N1' N2' Nsum')
+     (D2' : size (E2 E') N2')
+     (D1' : size (E1 E') N1'))
      DplusRes'
      <- subst-size E' D1 
-	(D1' : size (E1 E') N1')
-	(Dplus1 : plus Ndiff1 N1 N1')
+     (D1' : size (E1 E') N1')
+     (Dplus1 : plus Ndiff1 N1 N1')
      <- subst-size E' D2 
-	(D2' : size (E2 E') N2')
-	(Dplus2 : plus Ndiff2 N2 N2')
+     (D2' : size (E2 E') N2')
+     (Dplus2 : plus Ndiff2 N2 N2')
      <- lemma Dplus Dplus1 Dplus2 Dplus' DplusRes
      <- plus-s-rh DplusRes DplusRes'.
 
-%{!  !}%
-    
-%{! (options removed from twelftag: check="decl") !}%
+%{!! end hidden !!}%
+
+%{!! begin checked !!}%
 
 %block ssblock : block {y : tm} 
-		       {dy : size y (s z)}
-		       {_ : {E' : tm} subst-size E' ([x] [dx] dy) dy plus-z}.
+                       {dy : size y (s z)}
+                       {_ : {E' : tm} subst-size E' ([x] [dx] dy) dy plus-z}.
 %worlds (ssblock) (subst-size _ _ _ _).
 %total D (subst-size _ D _ _).
+
+%{!! end checked !!}%
 
 %{! The block ``ssblock`` extends ``size-block`` with a case of the theorem: when the size derivation is ``dy`` from the context, the term ``E`` must be ``[_] y``, so by inversion the derivation of ``size (([_] y) E') N'`` must be ``dy`` as well, in which case ``plus-z`` derives ``plus z (s z) (s z)``.  The only other change is that the premise of the case for ``size-lam`` adds this extra assumption to the context.  In this world, the relation is indeed total.  
 
@@ -452,11 +452,11 @@ subst-size : {E' : tm}
 
 We set out to prove
 
-: For all Γ in ``(size-block)*``, if ``Γ ⊦ E' : tm`` and ``Γ ⊦ D : \{x:tm\} size x (s z) -> size (E x) N`` and ``Γ ⊦ D' : size (E E') N'`` then there exist ``Ndiff`` and ``Dplus`` such that ``Γ ⊦ Dplus : plus Ndiff N N'``.
+> For all Γ in ``(size-block)*``, if ``Γ ⊦ E' : tm`` and ``Γ ⊦ D : {x:tm} size x (s z) -> size (E x) N`` and ``Γ ⊦ D' : size (E E') N'`` then there exist ``Ndiff`` and ``Dplus`` such that ``Γ ⊦ Dplus : plus Ndiff N N'``.
 
 But the corrected Twelf proof actually proves
 
-: For all Γ in ``(ssblock)*``, if ``Γ ⊦ E' : tm`` and ``Γ ⊦ D : \{x:tm\} size x (s z) -> size (E x) N`` and ``Γ ⊦ D' : size (E E') N'`` then there exist ``Ndiff`` and ``Dplus`` such that ``Γ ⊦ Dplus : plus Ndiff N N'``.
+> For all Γ in ``(ssblock)*``, if ``Γ ⊦ E' : tm`` and ``Γ ⊦ D : {x:tm} size x (s z) -> size (E x) N`` and ``Γ ⊦ D' : size (E E') N'`` then there exist ``Ndiff`` and ``Dplus`` such that ``Γ ⊦ Dplus : plus Ndiff N N'``.
 
 Did we prove the right theorem?  Not necessarily: it is possible that the contexts in ``(ssblock)*`` do not cover all open terms, or that they include inadequate derivations of ``plus Ndiff N N'``.  Thus, there is a danger here: we need to check that the second statement implies the first to see that we proved the right theorem.  
 
@@ -468,15 +468,4 @@ When you recast an informal theorem statement as a Twelf theorem statement, you 
 
 Putting a case of a theorem in the context is a general technique that is useful in many circumstances.  However, in this example, we can avoid putting the theorem case in the context by using a [catch-all case](/wiki/catch-all-case/), as the tutorial on that Twelf proof device explains.  
 
-\{\{proving metatheorems
-  | next = Summary: the STLC
-  | nextname = Summary
-  | prev = Proving metatheorems about the STLC
-  | prevname = Proving metatheorems\}\} !}%
-
-%{!
------
-This page was copied from the MediaWiki version of the Twelf Wiki.
-If anything looks wrong, you can refer to the
-[wayback machine's version here](https://web.archive.org/web/20240303030303/http://twelf.org/wiki/Proving_metatheorems:Proving_metatheorems_in_non-empty_contexts).
 !}%

--- a/wiki/pages/proving-metatheorems-proving-totality-assertions-in-non-empty-contexts.elf
+++ b/wiki/pages/proving-metatheorems-proving-totality-assertions-in-non-empty-contexts.elf
@@ -15,7 +15,9 @@ So far, we have only proved relations total in the empty LF context.  In this se
 ## Definition of Size
 
 The definition of size uses the definitions of [natural numbers](/wiki/proving-metatheorems-representing-the-syntax-of-the-natural-numbers/), [addition judgement](/wiki/proving-metatheorems-representing-the-judgements-of-the-natural-numbers/), and [STLC term syntax](/wiki/proving-metatheorems-representing-the-syntax-of-the-stlc/) from earlier in this introduction: !}%
-    
+
+%{!! begin hidden !!}%
+
 tp    : type.
 unit  : tp.
 arrow : tp -> tp -> tp.
@@ -34,10 +36,12 @@ plus   : nat -> nat -> nat -> type.
 
 plus-z : plus z N2 N2.
 plus-s : plus (s N1) N2 (s N3)
-	  <- plus N1 N2 N3.
+    <- plus N1 N2 N3.
 
 %worlds () (plus _ _ _).
 %total N (plus N _ _).
+
+%{!! end hidden !!}%
 
 %{! Informally, we define the size of a term as follows:
 * <Math formula="|x| = 1"/>
@@ -54,13 +58,13 @@ size       : tm -> nat -> type.
 
 size-empty : size empty (s z). 
 size-lam   : size (lam _ E) (s N)
-		<- ({x : tm} 
+                <- ({x : tm} 
                     {_ : size x (s z)}
-		      size (E x) N).
+                      size (E x) N).
 size-app   : size (app E1 E2) (s N)
-		<- size E1 N1
-		<- size E2 N2 
-		<- plus N1 N2 N.
+                <- size E1 N1
+                <- size E2 N2 
+                <- plus N1 N2 N.
 
 %{!! end checked !!}%
 
@@ -120,6 +124,7 @@ For example, ``(size-block)*`` subsumes the world containing only the empty cont
 Using world subsumption, we refine our notion of world checking as follows. A constant world checks iff
 - The world of a type family subsumes the world of each of its premises.
 - Each premise's local assumptions stay in the world for that type family.
+
 These conditions ensure that whenever the ambient LF context is of the form specified by the world declaration, for each premise of the constant, the world for the premise contains the restriction of the ambient context to the premise appended with the local assumptions made by the premise.
 
 Under this more permissive definition, the ``plus`` premise of ``size`` is deemed world-correct.
@@ -152,13 +157,13 @@ size       : tm -> nat -> type.
 
 size-empty : size empty (s z). 
 size-lam   : size (lam _ E) (s N)
-		<- ({x : tm} 
+                <- ({x : tm} 
                     {_ : size x (s z)}
-		      size (E x) N).
+                      size (E x) N).
 size-app   : size (app E1 E2) (s N)
-		<- size E1 N1
-		<- size E2 N2 
-		<- plus N1 N2 N.
+                <- size E1 N1
+                <- size E2 N2 
+                <- plus N1 N2 N.
 
 %block size-block : block {x : tm} {_ : size x (s z)}.
 %worlds (size-block) (size _ _).
@@ -169,9 +174,24 @@ size-app   : size (app E1 E2) (s N)
 
 One possible world error is to write a premise whose local context extensions do not stay in the appropriate world.   For example, if we forgot the ``size`` assumption in the ``lam`` case, Twelf would report an error: 
 
+!}%
+
+%{!! begin hidden !!}%
+size       : tm -> nat -> type.
+%mode size +E -N.
+
+size-empty : size empty (s z). 
+size-app   : size (app E1 E2) (s N)
+                <- size E1 N1
+                <- size E2 N2 
+                <- plus N1 N2 N.
+%{!! end hidden !!}%
+
+%{!
+
 ```checkedtwelf
 size-lam   : size (lam _ E) (s N)
-		<- ({x : tm} 		   
+                <- ({x : tm}
                       size (E x) N).
 %block size-block : block {x : tm} {_ : size x (s z)}.
 %worlds (size-block) (size _ _).
@@ -180,6 +200,25 @@ size-lam   : size (lam _ E) (s N)
 ### World subsumption failure
 
 Another possible world error is that world subsumption could fail.  For example, if ``size`` were stated for a  world containing natural number assumptions (which of course ruins the adequacy of ``nat`` for the natural numbers), it would not be permissible to call ``plus``:
+
+!}%
+
+%{!! begin hidden !!}%
+size       : tm -> nat -> type.
+%mode size +E -N.
+
+size-empty : size empty (s z). 
+size-lam   : size (lam _ E) (s N)
+                <- ({x : tm} 
+                    {_ : size x (s z)}
+                      size (E x) N).
+size-app   : size (app E1 E2) (s N)
+                <- size E1 N1
+                <- size E2 N2 
+                <- plus N1 N2 N.
+%{!! end hidden !!}%
+
+%{!
 
 ```checkedtwelf
 %block size-block : block {x : tm} {_ : size x (s z)}.
@@ -197,11 +236,11 @@ size       : tm -> nat -> type.
 
 size-empty : size empty (s z). 
 size-lam   : size (lam _ E) (s N)
-		<- ({x : tm} size (E x) N).
+    <- ({x : tm} size (E x) N).
 size-app   : size (app E1 E2) (s N)
-		<- size E1 N1
-		<- size E2 N2 
-		<- plus N1 N2 N.
+    <- size E1 N1
+    <- size E2 N2 
+    <- plus N1 N2 N.
 
 %block size-block : block {x : tm}.
 %worlds (size-block) (size _ _).


### PR DESCRIPTION
Updates to the various non-empty context tutorial pages.

Getting the `proving-metatheorems-proving-totality-assertions-in-non-empty-contexts` page to display the correct world errors was tricky for me so if there's a better way I'd be happy to fix it, thanks!